### PR TITLE
Removing the `look-up` as the names of the `ClusterRole` and `Binding` were changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed 🔧
 
-- [#](https://github.com/vaticyai/agent-chart/pull/) Removing the `look-up` as the names of the `ClusterRole` and `Binding` were changed
+- [#6](https://github.com/vaticyai/agent-chart/pull/6) Removing the `look-up` as the names of the `ClusterRole` and `Binding` were changed
 
 ## 0.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Vaticy Agent Chart
 
+## 0.1.7
+
+### Fixed 🔧
+
+- [#](https://github.com/vaticyai/agent-chart/pull/) Removing the `look-up` as the names of the `ClusterRole` and `Binding` were changed
+
 ## 0.1.6
 
 ### Enhancement 🏎️

--- a/templates/permissions/clusterRole.yaml
+++ b/templates/permissions/clusterRole.yaml
@@ -2,7 +2,6 @@
 {{- $apiGroupMapping := (include "apiGroupMapping" . | fromJson) }}
 {{- $values := .Values -}}
 {{- $release := .Release -}}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" $values.name) }}
 {{- range .Values.permissions -}}
   {{- if eq .namespace "*" }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,6 +17,5 @@ rules:
     {{- end }}
   {{- end }}
   {{- end -}}
-{{- end }}
 {{- end -}}
 {{- end }}

--- a/templates/permissions/clusterRoleBinding.yaml
+++ b/templates/permissions/clusterRoleBinding.yaml
@@ -1,7 +1,6 @@
 {{- if .Values.enabled }}
 {{- $values := .Values -}}
 {{- $release := .Release -}}
-{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" $values.name) }}
 {{- range .Values.permissions -}}
   {{- if eq .namespace "*" }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,7 +15,6 @@ subjects:
   - kind: ServiceAccount
     name: {{ $values.name }}-sa
     namespace: {{ $release.Namespace }}
-{{- end }}
 {{- end -}}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
Removing the `look-up` as the names of the `ClusterRole` and `Binding` were changed